### PR TITLE
Feat/[SSC-69] 해당 기수에 회원가입 대기 상태인 회원 조회

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/user/user/dto/response/PendSignupResponseDto.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/dto/response/PendSignupResponseDto.java
@@ -4,19 +4,23 @@ import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class PendSignupResponseDto {
 
-    private final Long userId;
-    private final String email;
-    private final String username;
-    private final UserStatus status;
+    private Long userId;
+    private String email;
+    private String username;
+    private UserStatus status;
+    private LocalDateTime createAt;
 
     @Builder
-    public PendSignupResponseDto(Long userId, String email, String username, UserStatus status) {
+    public PendSignupResponseDto(Long userId, String email, String username, UserStatus status, LocalDateTime createAt) {
         this.userId = userId;
         this.email = email;
         this.username = username;
         this.status = status;
+        this.createAt = createAt;
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/managerController/ManagerController.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/managerController/ManagerController.java
@@ -1,12 +1,17 @@
 package com.sparta.teamssc.domain.user.user.managerController;
 
 import com.sparta.teamssc.common.dto.ResponseDto;
+import com.sparta.teamssc.domain.board.board.dto.response.BoardListResponseDto;
 import com.sparta.teamssc.domain.user.user.dto.request.ApproveManagerRequestDto;
 import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
 import com.sparta.teamssc.domain.user.user.managerService.ManagerService;
+import com.sparta.teamssc.domain.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -50,14 +55,17 @@ public class ManagerController {
      * 회원가입 승인 대기자 조회 메서드
      * @return 바디에 반환
      */
-    @GetMapping("/signup/pend/")
-    public ResponseEntity<ResponseDto<List<PendSignupResponseDto>>> getPendSignup() {
+    @GetMapping("/signup/pend")
+    public ResponseEntity<ResponseDto<Page<PendSignupResponseDto>>> getPendSignup(@RequestParam(value = "page", defaultValue = "1") int page,
+                                                                                  @AuthenticationPrincipal UserDetails userDetails) {
 
-        List<PendSignupResponseDto> pendSignupResponseDto = managerService.getPendSignup();
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.<List<PendSignupResponseDto>>builder()
-                .message("회원가입 승인 대기자가 조회 되었습니다.")
-                .data(pendSignupResponseDto)
-                .build());
+        Page<PendSignupResponseDto> responseDto = managerService.getPendSignup(page - 1, userDetails.getUsername());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.<Page<PendSignupResponseDto>>builder()
+                        .message("회원가입 승인 대기자가 조회 되었습니다.")
+                        .data(responseDto)
+                        .build());
     }
 
     @PostMapping("/period/manager")

--- a/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerService.java
@@ -2,8 +2,7 @@ package com.sparta.teamssc.domain.user.user.managerService;
 
 import com.sparta.teamssc.domain.user.user.dto.request.ApproveManagerRequestDto;
 import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public interface ManagerService {
 
@@ -11,7 +10,7 @@ public interface ManagerService {
 
     void signupRefusal(Long userId);
 
-    List<PendSignupResponseDto> getPendSignup();
+    Page<PendSignupResponseDto> getPendSignup(int page, String email);
 
     void approveManager(ApproveManagerRequestDto approveManagerRequestDto);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerServiceImpl.java
@@ -1,5 +1,7 @@
 package com.sparta.teamssc.domain.user.user.managerService;
 
+import com.sparta.teamssc.domain.board.board.dto.response.BoardListResponseDto;
+import com.sparta.teamssc.domain.period.entity.Period;
 import com.sparta.teamssc.domain.user.role.userRole.service.UserRoleService;
 import com.sparta.teamssc.domain.user.user.dto.request.ApproveManagerRequestDto;
 import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
@@ -8,6 +10,10 @@ import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import com.sparta.teamssc.domain.user.user.repository.UserRepository;
 import com.sparta.teamssc.domain.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,13 +53,15 @@ public class ManagerServiceImpl implements ManagerService{
 
     // 회원가입 승인 대기자 조회
     @Override
-    public List<PendSignupResponseDto> getPendSignup() {
+    public Page<PendSignupResponseDto> getPendSignup(int page, String email) {
 
-        List<User> pendSignupList = userService.findByStatus(UserStatus.PENDING);
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createAt"));
 
-        return pendSignupList.stream()
-                .map(user -> new PendSignupResponseDto(user.getId(), user.getEmail(), user.getUsername(), user.getStatus()))
-                .collect(Collectors.toList());
+        Period period = userService.getUserByEmail(email).getPeriod();
+
+        Page<PendSignupResponseDto> pendPage = userService.findPagedPendList(pageable, period);
+
+        return pendPage;
     }
 
     //매니저 권한 부여

--- a/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserCustomRepository.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserCustomRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.teamssc.domain.user.user.repository;
+
+import com.sparta.teamssc.domain.period.entity.Period;
+import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserCustomRepository {
+
+    Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period);
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.sparta.teamssc.domain.user.user.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.teamssc.domain.period.entity.Period;
+import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
+import com.sparta.teamssc.domain.user.user.entity.QUser;
+import com.sparta.teamssc.domain.user.user.entity.UserStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period) {
+        QUser qUser = QUser.user;
+
+        List<PendSignupResponseDto> pendList = jpaQueryFactory
+                .select(Projections.constructor(PendSignupResponseDto.class,
+                        qUser.id,
+                        qUser.email,
+                        qUser.username,
+                        qUser.status,
+                        qUser.createAt
+                ))
+                .from(qUser)
+                .orderBy(qUser.createAt.desc())
+                .where(qUser.status.eq(UserStatus.PENDING))
+                .where(qUser.period.eq(period))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(pendList, pageable, pendList.size());
+    }
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserRepository.java
@@ -11,15 +11,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
     @EntityGraph(attributePaths = {"roles", "roles.role"})
     Optional<User> findByEmail(String email);
 
     Optional<User> findByUsername(String username);
 
     Optional<User> findById(Long id);
-
-    List<User> findByStatus(UserStatus userStatus);
 
     Page<ProfileCardMapper> findAllByOrderByCreateAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -1,8 +1,12 @@
 package com.sparta.teamssc.domain.user.user.service;
 
+import com.sparta.teamssc.common.dto.ResponseDto;
+import com.sparta.teamssc.domain.period.dto.PeriodResponseDto;
+import com.sparta.teamssc.domain.period.entity.Period;
 import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
+import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
 import com.sparta.teamssc.domain.user.user.entity.User;
 import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import com.sparta.teamssc.domain.user.user.repository.userMapping.ProfileCardMapper;
@@ -42,6 +46,6 @@ public interface UserService {
     //유저 페이징
     Page<ProfileCardMapper> findAllUsers(Pageable pageable);
 
-    //유저Status로 사용자 가져오기
-    List<User> findByStatus(UserStatus userStatus);
+    // 회원가입 대기 상태 유저 페이징
+    Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sparta.teamssc.domain.user.user.service;
 
+import com.sparta.teamssc.domain.board.board.dto.response.BoardListResponseDto;
 import com.sparta.teamssc.domain.period.entity.Period;
 import com.sparta.teamssc.domain.period.service.PeriodService;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
@@ -10,6 +11,7 @@ import com.sparta.teamssc.domain.user.refreshToken.entity.RefreshToken;
 import com.sparta.teamssc.domain.user.refreshToken.service.RefreshTokenService;
 import com.sparta.teamssc.domain.user.role.userRole.entity.UserRole;
 import com.sparta.teamssc.domain.user.role.userRole.service.UserRoleService;
+import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
 import com.sparta.teamssc.domain.user.user.entity.User;
 import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import com.sparta.teamssc.domain.user.user.repository.UserRepository;
@@ -211,10 +213,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<User> findByStatus(UserStatus status) {
-        return userRepository.findByStatus(UserStatus.PENDING);
+    public Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period) {
+        return userRepository.findPagedPendList(pageable, period);
     }
-
 
     private Collection<? extends GrantedAuthority> mapRolesToAuthorities(Set<UserRole> roles) {
         return roles.stream()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [SSC-79] 기수 조회 

## 📝 작업 내용

- 기수 조회 시 페이징 처리 하여 해당 기수에 회원 가입 대기 상태인 회원만 조회 되도록 수정하였습니다

### 📸 스크린샷 (선택)

- 페이징 조회
<img width="824" alt="image" src="https://github.com/user-attachments/assets/42de7af5-d3b9-4ff3-bcfa-cd1078fdd145">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-79]: https://dami8789.atlassian.net/browse/SSC-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ