### PR TITLE
fix/[SSC-47]: 전체 프로필 조회 기수에 대한 전체 프로필 조회로 수정

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/LoginResponseDto.java
@@ -10,12 +10,16 @@ public class LoginResponseDto {
     private final String refreshToken;
     private final String username;
     private final Long periodId;
+    private final String trackName;
+    private final int period;
 
     @Builder
-    public LoginResponseDto(String accessToken, String refreshToken, String username, Long periodId) {
+    public LoginResponseDto(String accessToken, String refreshToken, String username, Long periodId, String trackName, int period) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.username = username;
         this.periodId = periodId;
+        this.trackName = trackName;
+        this.period = period;
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/profile/controller/ProfileController.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/profile/controller/ProfileController.java
@@ -81,12 +81,13 @@ public class ProfileController {
     }
 
     @GetMapping("/users/profiles")
-    public ResponseEntity<ResponseDto<Page<ProfileCardMapper>>> getAllProfiles(@RequestParam int page) {
+    public ResponseEntity<ResponseDto<Page<ProfileCardMapper>>> getAllProfiles(@RequestParam int page,
+                                                                               @AuthenticationPrincipal UserDetails userDetails) {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.<Page<ProfileCardMapper>>builder()
                         .message("프로필카드 목록 조회에 성공했습니다.")
-                        .data(profileService.getAllProfiles(page))
+                        .data(profileService.findMemberCards(page,userDetails.getUsername()))
                         .build());
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/profile/service/ProfileService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/profile/service/ProfileService.java
@@ -25,5 +25,5 @@ public interface ProfileService {
     ProfileResponseDto searchProfile(Long email);
 
     //멤버카드들 조회
-    Page<ProfileCardMapper> getAllProfiles(int page);
+    Page<ProfileCardMapper> findMemberCards(int page,String email);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/profile/service/ProfileServiceImpl.java
@@ -93,11 +93,10 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public Page<ProfileCardMapper> getAllProfiles(int page) {
+    public Page<ProfileCardMapper> findMemberCards(int page,String email) {
+
             Pageable pageable = PageRequest.of(page - 1, 10);
 
-            Page<ProfileCardMapper> profileCards = userService.findAllUsers(pageable);
-
-            return profileCards;
+        return userService.findMemberCards(pageable,email);
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.teamssc.domain.user.user.repository;
 
+import com.sparta.teamssc.domain.period.entity.Period;
 import com.sparta.teamssc.domain.user.user.entity.User;
 import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import com.sparta.teamssc.domain.user.user.repository.userMapping.ProfileCardMapper;
@@ -7,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,5 +22,9 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     Optional<User> findById(Long id);
 
-    Page<ProfileCardMapper> findAllByOrderByCreateAtDesc(Pageable pageable);
+    @Query("SELECT u.id AS id, u.username AS username " +
+            "FROM User u " +
+            "WHERE (u.period = :periodId) " +
+            "ORDER BY u.createAt")
+    Page<ProfileCardMapper> findMemberCards(@Param("periodId") Period periodId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -47,7 +47,7 @@ public interface UserService {
     User findById(Long id);
 
     //유저 페이징
-    Page<ProfileCardMapper> findAllUsers(Pageable pageable);
+    Page<ProfileCardMapper> findMemberCards(Pageable pageable, String email);
 
     // 회원가입 대기 상태 유저 페이징
     Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period);

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -126,6 +126,8 @@ public class UserServiceImpl implements UserService {
                 .refreshToken(refreshToken)
                 .username(user.getUsername())
                 .periodId(user.getPeriod().getId())
+                .period(user.getPeriod().getPeriod())
+                .trackName(user.getPeriod().getTrack().getName())
                 .build();
     }
 
@@ -178,8 +180,12 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Page<ProfileCardMapper> findAllUsers(Pageable pageable) {
-        return userRepository.findAllByOrderByCreateAtDesc(pageable);
+    public Page<ProfileCardMapper> findMemberCards(Pageable pageable,String email) {
+
+        User user = getUserByEmail(email);
+        Period period = user.getPeriod();
+
+        return userRepository.findMemberCards(period,pageable);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) [SSC-47] 

## 📝 작업 내용

> 기수에 대한 프로필 전체 조회로 수정했습니다. 기수가 있는 아이디의 토큰만 취급합니다.
### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d893a0c9-a997-4725-ac34-82fc6925301c)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-47]: https://dami8789.atlassian.net/browse/SSC-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ