### PR TITLE
fix[SSC-89]: 팀명 리더 수정 권한 수정

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -233,6 +233,7 @@ public class UserServiceImpl implements UserService {
         return userRepository.findPagedPendList(pageable, period);
     }
 
+
     private Collection<? extends GrantedAuthority> mapRolesToAuthorities(Set<UserRole> roles) {
         return roles.stream()
                 .map(role -> new SimpleGrantedAuthority(role.getRole().getName()))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) [SSC-89] 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 팀원만 팀명 팀 리더 수정가능
- 팀원만 리더 가능
### 📸 스크린샷 (선택)
<img width="690" alt="image" src="https://github.com/user-attachments/assets/f76c71e2-dd16-41ab-a78e-5ca75c3b2338">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-89]: https://dami8789.atlassian.net/browse/SSC-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ