### PR TITLE
fix/[SSC-47]: 팀에 대한 유저 프로필 검색

### DIFF
--- a/src/main/java/com/sparta/teamssc/common/config/WebMvcConfig.java
+++ b/src/main/java/com/sparta/teamssc/common/config/WebMvcConfig.java
@@ -13,7 +13,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000")
-                .allowedMethods("OPTIONS","GET","POST","PUT","DELETE");
+                .allowedMethods("OPTIONS","GET","POST","PUT","DELETE","PATCH");
     }
 }
 

--- a/src/main/java/com/sparta/teamssc/domain/image/entity/FileContentType.java
+++ b/src/main/java/com/sparta/teamssc/domain/image/entity/FileContentType.java
@@ -1,7 +1,7 @@
 package com.sparta.teamssc.domain.image.entity;
 
 public enum FileContentType {
-    JPG("image/jpeg"),
+    JPG("image/jpg"),
     PNG("image/png"),
     JPEG("image/jpeg"),
     MP4("video/mp4"),

--- a/src/main/java/com/sparta/teamssc/domain/team/dto/response/TeamMemberResponseDto.java
+++ b/src/main/java/com/sparta/teamssc/domain/team/dto/response/TeamMemberResponseDto.java
@@ -14,6 +14,6 @@ public class TeamMemberResponseDto {
 
     // 팀명
     private String teamName;
-    private List<String> userEmails;
+    private List<Long> userIds;
     private List<String> userNames;
 }

--- a/src/main/java/com/sparta/teamssc/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/team/service/TeamServiceImpl.java
@@ -239,7 +239,7 @@ public class TeamServiceImpl implements TeamService {
         return TeamMemberResponseDto.builder()
                 .currentWeekProgress(team.getWeekProgress().getName())
                 .teamName(team.getTeamName())
-                .userEmails(members.stream().map(User::getEmail).collect(Collectors.toList()))
+                .userIds(members.stream().map(User::getId).collect(Collectors.toList()))
                 .userNames(members.stream().map(User::getUsername).collect(Collectors.toList()))
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) [SSC-47] 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
검색했을때 이메일 배열이랑, 유저네임배열이 나왔는데 이메일 배열을 유저ID값 배열로 수정
### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bc211e51-6549-47d6-aee7-14417210a968)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-47]: https://dami8789.atlassian.net/browse/SSC-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ