### PR TITLE
Feat/[SSC-86] : 이메일 발송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,15 @@ repositories {
 }
 
 dependencies {
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'javax.mail:mail:1.4.7'
+
+    // Spring Context Support
+    implementation 'org.springframework:spring-context-support:5.3.9'
+
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -45,7 +54,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'

--- a/src/main/java/com/sparta/teamssc/domain/email/EmailConfig.java
+++ b/src/main/java/com/sparta/teamssc/domain/email/EmailConfig.java
@@ -1,0 +1,42 @@
+package com.sparta.teamssc.domain.email;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${EMAIL_USERNAME}")
+    private String username;
+
+    @Value("${EMAIL_PASSWORD}")
+    private String password;
+
+    @Bean
+    public JavaMailSender mailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties javaMailProperties = new Properties();//JavaMail의 속성을 설정하기 위해 Properties 객체를 생성
+        javaMailProperties.put("mail.transport.protocol", "smtp");//프로토콜로 smtp 사용
+        javaMailProperties.put("mail.smtp.auth", "true");//smtp 서버에 인증이 필요
+        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");//SSL 소켓 팩토리 클래스 사용
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
+        javaMailProperties.put("mail.debug", "true");//디버깅 정보 출력
+        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.gmail.com");//smtp 서버의 ssl 인증서를 신뢰
+        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");//사용할 ssl 프로토콜 버젼
+
+        mailSender.setJavaMailProperties(javaMailProperties);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/sparta/teamssc/domain/email/EmailController.java
+++ b/src/main/java/com/sparta/teamssc/domain/email/EmailController.java
@@ -1,0 +1,49 @@
+package com.sparta.teamssc.domain.email;
+
+import com.sparta.teamssc.domain.email.EmailService;
+import com.sparta.teamssc.domain.user.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email")
+public class EmailController {
+
+    private final EmailService emailService;
+    private final UserService userService;
+
+    /**
+     * 이메일 발송 메서드
+     * @param email
+     * @return 바디에 반환
+     */
+    @PostMapping("/send")
+    public ResponseEntity<String> sendVerificationEmail(@RequestParam("email") String email) {
+        try {
+            String authNumber = emailService.joinEmail(email);
+            return ResponseEntity.ok(authNumber);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("이메일 전송에 실패했습니다.");
+        }
+    }
+
+//    /**
+//     * 이메일 인증
+//     * @param username 사용자 이름
+//     * @param verificationCode 인증 코드
+//     * @return 인증 성공 또는 실패 메시지
+//     */
+//    @PostMapping("/verify-email")
+//    public ResponseEntity<String> verifyEmail(@RequestParam String username, @RequestParam String verificationCode) {
+//        boolean isVerified = userService.verifyEmail(username, verificationCode);
+//        if (isVerified) {
+//            return ResponseEntity.ok("이메일 인증 성공");
+//        } else {
+//            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이메일 인증 실패");
+//        }
+//    }
+}
+

--- a/src/main/java/com/sparta/teamssc/domain/email/EmailService.java
+++ b/src/main/java/com/sparta/teamssc/domain/email/EmailService.java
@@ -1,0 +1,73 @@
+package com.sparta.teamssc.domain.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    @Autowired
+    private final JavaMailSender mailSender;
+
+    private int authNumber;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    //임의의 6자리 양수를 반환합니다.
+    public void makeRandomNumber() {
+        Random r = new Random();
+        String randomNumber = "";
+        for(int i = 0; i < 6; i++) {
+            randomNumber += Integer.toString(r.nextInt(10));
+        }
+
+        authNumber = Integer.parseInt(randomNumber);
+    }
+
+    //mail을 어디서 보내는지, 어디로 보내는지 , 인증 번호를 html 형식으로 어떻게 보내는지 작성합니다.
+    public String joinEmail(String email) {
+        makeRandomNumber();
+        String setFrom = "teamssc2@gmail.com"; // email-config에 설정한 자신의 이메일 주소를 입력
+        String toMail = email;
+        String title = "스파르타 스마트 코치 회원 가입 인증 이메일 입니다."; // 이메일 제목
+        String content =
+                        "<br><br>" +
+                        "인증 번호는 " + authNumber + "입니다." +
+                        "<br>" +
+                        "인증번호를 제대로 입력해주세요"; //이메일 내용 삽입
+        mailSend(setFrom, toMail, title, content);
+        return Integer.toString(authNumber);
+    }
+
+    // 이메일 전송 메서드
+    public void mailSend(String setFrom, String toMail, String title, String content) {
+
+        //JavaMailSender 객체를 사용하여 MimeMessage 객체를 생성
+        MimeMessage message = mailSender.createMimeMessage();
+
+        try {
+            // true를 전달하여 multipart 형식의 메시지를 지원하고, "utf-8"을 전달하여 문자 인코딩을 설정
+            MimeMessageHelper helper = new MimeMessageHelper(message,true,"utf-8");
+            helper.setFrom(setFrom);//이메일의 발신자 주소 설정
+            helper.setTo(toMail);//이메일의 수신자 주소 설정
+            helper.setSubject(title);//이메일의 제목을 설정
+            helper.setText(content,true);//이메일의 내용 설정 두 번째 매개 변수에 true를 설정하여 html 설정으로한다.
+            mailSender.send(message);
+
+        } catch (MessagingException e) {//이메일 서버에 연결할 수 없거나, 잘못된 이메일 주소를 사용하거나, 인증 오류가 발생하는 등 오류
+            // 이러한 경우 MessagingException이 발생
+            e.printStackTrace();//e.printStackTrace()는 예외를 기본 오류 스트림에 출력하는 메서드
+        }
+    }
+}
+

--- a/src/main/java/com/sparta/teamssc/domain/email/RedisConfig.java
+++ b/src/main/java/com/sparta/teamssc/domain/email/RedisConfig.java
@@ -1,0 +1,27 @@
+//package com.sparta.teamssc.domain.email;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.redis.connection.RedisConnectionFactory;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.serializer.StringRedisSerializer;
+//
+//
+//@Configuration
+//public class RedisConfig {
+//
+//    /**
+//     * redistemplete
+//     * @param connectionFactory
+//     * @return
+//     */
+//    @Bean
+//    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+//        RedisTemplate<String, String> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//        //  Redis는 데이터를 바이너리 형태로 저장
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setValueSerializer(new StringRedisSerializer());
+//        return template;
+//    }
+//}

--- a/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
@@ -114,4 +114,6 @@ public class User extends BaseEntity {
     public void withdrawn() {
         this.status = UserStatus.WITHDRAWN;
     }
+
+//    public void updateStatus() { this.status = UserStatus.PENDING; }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -51,4 +51,6 @@ public interface UserService {
 
     // 회원가입 대기 상태 유저 페이징
     Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period);
+
+//    boolean verifyEmail(String username, String verificationCode);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -21,15 +21,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -41,6 +39,7 @@ public class UserServiceImpl implements UserService {
     private final RefreshTokenService refreshTokenService;
     private final UserRoleService userRoleService;
     private final PeriodService periodService;
+//    private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${secret.admin-key}")
     String adminKey;
@@ -176,6 +175,28 @@ public class UserServiceImpl implements UserService {
 
         userRepository.save(user);
     }
+
+//    /**
+//     * 이메일 인증: 입력한 인증 코드를 검증
+//     *
+//     * @param email         사용자 이름
+//     * @param verificationCode 입력한 인증 코드
+//     * @return 인증 성공 여부
+//     */
+//    @Override
+//    @Transactional
+//    public boolean verifyEmail(String email, String verificationCode) {
+//        String storedCode = redisTemplate.opsForValue().get(email);
+//        if (storedCode != null && storedCode.equals(verificationCode)) {
+//            Optional<User> userOptional = userRepository.findByEmail(email);
+//            if (userOptional.isPresent()) {
+//                User user = userOptional.get();
+//                user.updateStatus();
+//                return true;
+//            }
+//        }
+//        return false;
+//    }
 
     @Override
     public Page<ProfileCardMapper> findAllUsers(Pageable pageable) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,16 @@
 spring:
   application:
     name: TeamSsc
+
+    mail:
+      password: ${EMAIL_PASSWORD}
+      username: ${EMAIL_USERNAME}
+      properties:
+        mail:
+          smtp:
+            auth: true
+            starttls:
+              enable: true
   servlet:
     multipart:
       enabled: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [SSC-87] 회원가입 시 이메일 인증번호 발송

## 📝 작업 내용

- 회원가입 시 사용자가 입력한 이메일로 인증번호 발송하는 기능 구현입니다.
- 주석 처리 한 부분은 이메일 인증 부분으로 추후 redis 사용시 해제 예정입니다.

### 📸 스크린샷 (선택)

- 인증번호 발송 
<img width="833" alt="image" src="https://github.com/user-attachments/assets/d557022d-602c-4c58-9d00-41606f0303d5">

<img width="946" alt="image" src="https://github.com/user-attachments/assets/9e3fbfce-2c38-4bb3-89f5-7dabb4bf7585">



## 💬 리뷰 요구사항(선택)

- 처음 구현해 보는 기능이라 부족한 부분이 있을 것으로 예상됩니다.. 리뷰 해주시면 수정 하도록 하겠습니다..!


[SSC-87]: https://dami8789.atlassian.net/browse/SSC-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ