### PR TITLE
feat[SSC-90] OAuth 카카오로그인

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/user/auth/config/RestTemplateConfig.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/config/RestTemplateConfig.java
@@ -1,0 +1,22 @@
+package com.sparta.teamssc.domain.user.auth.config;
+
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig  {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+                // 무한 대기 상태 방지를 위해 강제 종료 설정
+                .setConnectTimeout(Duration.ofSeconds(5)) // 5초
+                .setReadTimeout(Duration.ofSeconds(5)) // 5초
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/controller/AuthController.java
@@ -1,10 +1,15 @@
 package com.sparta.teamssc.domain.user.auth.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sparta.teamssc.common.dto.ResponseDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
+import com.sparta.teamssc.domain.user.auth.service.KakaoService;
+import com.sparta.teamssc.domain.user.auth.util.JwtUtil;
 import com.sparta.teamssc.domain.user.user.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserService userService;
+    private final KakaoService kakaoService;
 
     // 회원가입
     @PostMapping("/users/signup")
@@ -98,6 +104,21 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.<String>builder()
                         .message("회원탈퇴 성공했습니다.")
+                        .build());
+    }
+
+    /**
+     * 카카오 로그인
+     */
+    @GetMapping("/user/kakao/callback")
+    public ResponseEntity<ResponseDto<LoginResponseDto>> kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+
+        LoginResponseDto loginResponseDto = kakaoService.kakaoLogin(code);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.<LoginResponseDto>builder()
+                        .message("카카오 로그인")
+                        .data(loginResponseDto)
                         .build());
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/dto/KakaoUserInfoDto.java
@@ -1,0 +1,20 @@
+package com.sparta.teamssc.domain.user.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String nickname;
+    private String imageUrl;
+    private String email;
+
+    public KakaoUserInfoDto(Long id, String nickname, String imageUrl, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoService.java
@@ -1,0 +1,17 @@
+package com.sparta.teamssc.domain.user.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.teamssc.domain.user.auth.dto.KakaoUserInfoDto;
+import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
+import com.sparta.teamssc.domain.user.user.entity.User;
+
+public interface KakaoService {
+
+    LoginResponseDto kakaoLogin(String code) throws JsonProcessingException;
+
+    String getToken(String code) throws JsonProcessingException;
+
+    KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException;
+
+    User registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo);
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -1,0 +1,193 @@
+package com.sparta.teamssc.domain.user.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.teamssc.domain.user.auth.dto.KakaoUserInfoDto;
+import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
+import com.sparta.teamssc.domain.user.auth.util.JwtUtil;
+import com.sparta.teamssc.domain.user.refreshToken.service.RefreshTokenService;
+import com.sparta.teamssc.domain.user.role.userRole.service.UserRoleService;
+import com.sparta.teamssc.domain.user.user.entity.User;
+import com.sparta.teamssc.domain.user.user.entity.UserStatus;
+import com.sparta.teamssc.domain.user.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j(topic = "KAKAO Login")
+@Service
+@RequiredArgsConstructor
+public class KakaoServiceImpl implements KakaoService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final UserRoleService userRoleService;
+    private final RestTemplate restTemplate;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public LoginResponseDto kakaoLogin(String code) throws JsonProcessingException {
+
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getToken(code);
+
+        // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+
+        // 3. 필요시에 회원가입
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        // 4. JWT 토큰 반환
+        List<String> roles = kakaoUser.getRoles().stream()
+                .map(userRole -> userRole.getRole().getName())
+                .collect(Collectors.toList());
+
+        String newAccessToken = jwtUtil.createAccessToken(kakaoUser.getEmail(), roles); // 새로운 엑세스 토큰 생성
+        String newRefreshToken = jwtUtil.createRefreshToken(kakaoUser.getEmail(), roles); // 새로운 리프레시 토큰 생성
+
+        refreshTokenService.updateRefreshToken(kakaoUser, newRefreshToken); // 리프레시 토큰 업데이트
+
+        return LoginResponseDto.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .username(kakaoUser.getUsername())
+                .build();
+
+    }
+
+    @Override
+    public String getToken(String code) throws JsonProcessingException {
+
+        log.info("인가코드 : " + code);
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "7cf9695ccd3477922a5d6ddef0793d97");
+        body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    @Override
+    public KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+
+        log.info("accessToken : " + accessToken);
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String image_url = jsonNode.get("kakao_account").get("profile")
+                .get("profile_image_url").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + image_url + ", " + email);
+        return new KakaoUserInfoDto(id, nickname, image_url, email);
+    }
+
+    public User registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
+
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoUserInfo.getId();
+        User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null);
+
+        if (kakaoUser == null) {
+
+            // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
+            String kakaoEmail = kakaoUserInfo.getEmail();
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
+
+            if (sameEmailUser != null) {
+
+                kakaoUser = sameEmailUser;
+                // 기존 회원정보에 카카오 Id 추가
+                kakaoUser = kakaoUser.kakaoIdUpdate(kakaoId);
+
+            } else {
+
+                // 신규 회원가입
+                String password = UUID.randomUUID().toString();
+                String encodedPassword = passwordEncoder.encode(password);
+                String email = kakaoUserInfo.getEmail();
+
+                kakaoUser = User.builder()
+                        .email(email)
+                        .password(encodedPassword)
+                        .username(kakaoUserInfo.getNickname())
+                        .status(UserStatus.PENDING)
+                        .kakaoId(kakaoId)
+                        .build();
+            }
+
+            userRepository.save(kakaoUser);
+            userRoleService.userRoleAdd(kakaoUser, "user");
+
+        }
+        return kakaoUser;
+    }
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -146,7 +146,6 @@ public class KakaoServiceImpl implements KakaoService {
         String email = jsonNode.get("kakao_account")
                 .get("email").asText();
 
-        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + image_url + ", " + email);
         return new KakaoUserInfoDto(id, nickname, image_url, email);
     }
 
@@ -181,6 +180,7 @@ public class KakaoServiceImpl implements KakaoService {
                         .username(kakaoUserInfo.getNickname())
                         .status(UserStatus.PENDING)
                         .kakaoId(kakaoId)
+                        .profileImage(kakaoUserInfo.getImageUrl())
                         .build();
             }
 

--- a/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
@@ -75,13 +75,14 @@ public class User extends BaseEntity {
     private Long kakaoId;
 
     @Builder
-    public User(String email, String password, String username, UserStatus status, Period period, Long kakaoId) {
+    public User(String email, String password, String username, UserStatus status, Period period, Long kakaoId, String profileImage) {
         this.email = email;
         this.password = password;
         this.username = username;
         this.status = status;
         this.period = period;
         this.kakaoId = kakaoId;
+        this.profileImage = profileImage;
     }
 
     public void login() {

--- a/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
@@ -71,13 +71,17 @@ public class User extends BaseEntity {
     @JoinColumn(name = "period_id")
     private Period period;
 
+    @Column(name = "kakaoId")
+    private Long kakaoId;
+
     @Builder
-    public User(String email, String password, String username, UserStatus status, Period period) {
+    public User(String email, String password, String username, UserStatus status, Period period, Long kakaoId) {
         this.email = email;
         this.password = password;
         this.username = username;
         this.status = status;
         this.period = period;
+        this.kakaoId = kakaoId;
     }
 
     public void login() {
@@ -113,5 +117,10 @@ public class User extends BaseEntity {
 
     public void withdrawn() {
         this.status = UserStatus.WITHDRAWN;
+    }
+
+    public User kakaoIdUpdate(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/repository/UserRepository.java
@@ -22,6 +22,8 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     Optional<User> findById(Long id);
 
+    Optional<User> findByKakaoId(Long kakaoId);
+
     @Query("SELECT u.id AS id, u.username AS username " +
             "FROM User u " +
             "WHERE (u.period = :periodId) " +


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) [SSC-90] 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
> 카카오 로그인 시 회원가입 기능 구현
> 카카오에서 이름, 프로필사진url, 이메일 을 받아와서 user 테이블에 저장
> user 테이블에 kakaoId 컬럼 값이 있으면 kakaoId 입니다. 카카오에서 받아오는 id입니다.
> 카카오 로그인 시 status : PENDING, role : user
> 기수는 한 화면에서 같이 못해서 따로 기수추가하는 기능을 추가할 예정입니다

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4103aca1-135f-44c2-8645-43752e57187f)
![image](https://github.com/user-attachments/assets/676a6fd1-47f3-4314-94f2-06f9baa7ea88)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-90]: https://dami8789.atlassian.net/browse/SSC-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ