### PR TITLE
fix[SSC-89]: 매니저권한은 1번만 가능하게 제한

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerServiceImpl.java
@@ -69,7 +69,14 @@ public class ManagerServiceImpl implements ManagerService{
     public void approveManager(ApproveManagerRequestDto approveManagerRequestDto) {
 
         User user = userService.getUserByEmail(approveManagerRequestDto.getUserEmail());
+        //매니저인지 확인
+        boolean hasManagerRole = user.getRoles().stream()
+                        .anyMatch(role -> role.getRole().getName().equals("MANAGER"));
+        if (hasManagerRole) {
+            throw new IllegalArgumentException("이미 매니저 권한입니다.");
+        }
 
         userRoleService.userRoleAdd(user,"manager");
     }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) [SSC-89] 

## 📝 작업 내용
- 매니저 권한 부여는 매니저가 아닌 사람만 가능

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 📸 스크린샷 (선택)
<img width="521" alt="image" src="https://github.com/user-attachments/assets/393c3559-3a9c-45a4-9475-fdce93c8d420">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-89]: https://dami8789.atlassian.net/browse/SSC-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ