### PR TITLE
Fix[SSC-90] 카카오 로그인 

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/board/comment/entity/Comment.java
+++ b/src/main/java/com/sparta/teamssc/domain/board/comment/entity/Comment.java
@@ -23,7 +23,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -133,6 +134,20 @@ public class AuthController {
                 .body(ResponseDto.<KakaoUserStatusResponse>builder()
                         .message("카카오 유저 기수 신청 상태를 조회했습니다.")
                         .data(kakaoUserStatusResponse)
+                        .build());
+    }
+
+    // 카카오 유저 기수 신청
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/kakao/users/periods/{periodId}")
+    public ResponseEntity<ResponseDto<String>> kakaoUserUpdatePeriod(@PathVariable Long periodId,
+                                                                     @AuthenticationPrincipal UserDetails userDetails) {
+
+        userService.kakaoUserUpdatePeriod(periodId, userDetails.getUsername());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.<String>builder()
+                        .message("기수 신청에 성공했습니다.")
                         .build());
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sparta.teamssc.common.dto.ResponseDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
+import com.sparta.teamssc.domain.user.auth.dto.response.KakaoUserStatusResponse;
 import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
 import com.sparta.teamssc.domain.user.auth.service.KakaoService;
 import com.sparta.teamssc.domain.user.auth.util.JwtUtil;
@@ -119,6 +120,19 @@ public class AuthController {
                 .body(ResponseDto.<LoginResponseDto>builder()
                         .message("카카오 로그인")
                         .data(loginResponseDto)
+                        .build());
+    }
+
+    // 카카오 가입 유저 기수 신청 상태 확인
+    @GetMapping("/kakao/users/status")
+    public ResponseEntity<ResponseDto<KakaoUserStatusResponse>> getKakaoUserStatus(@AuthenticationPrincipal UserDetails userDetails) {
+
+        KakaoUserStatusResponse kakaoUserStatusResponse = userService.getKakaoUserStatus(userDetails.getUsername());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.<KakaoUserStatusResponse>builder()
+                        .message("카카오 유저 기수 신청 상태를 조회했습니다.")
+                        .data(kakaoUserStatusResponse)
                         .build());
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/KakaoUserStatusResponse.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/KakaoUserStatusResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.teamssc.domain.user.auth.dto.response;
+
+import com.sparta.teamssc.domain.user.user.entity.UserStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class KakaoUserStatusResponse {
+
+    private final Long periodId;
+    private final String trackName;
+    private final int period;
+
+    @Builder
+    public KakaoUserStatusResponse(Long periodId, String trackName, int period) {
+        this.periodId = periodId;
+        this.trackName = trackName;
+        this.period = period;
+    }
+}

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.teamssc.domain.user.auth.dto.response;
 
+import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,14 +13,16 @@ public class LoginResponseDto {
     private final Long periodId;
     private final String trackName;
     private final int period;
+    private final UserStatus userStatus;
 
     @Builder
-    public LoginResponseDto(String accessToken, String refreshToken, String username, Long periodId, String trackName, int period) {
+    public LoginResponseDto(String accessToken, String refreshToken, String username, Long periodId, String trackName, int period, UserStatus userStatus) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.username = username;
         this.periodId = periodId;
         this.trackName = trackName;
         this.period = period;
+        this.userStatus = userStatus;
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/dto/response/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.teamssc.domain.user.auth.dto.response;
 
+import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -170,10 +170,6 @@ public class KakaoServiceImpl implements KakaoService {
         Long kakaoId = kakaoUserInfo.getId();
         User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null);
 
-        if (kakaoUser.getPeriod() == null) {
-            kakaoUser.updateKakaoUserStatus();
-        }
-
         if (kakaoUser == null) {
 
             // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -68,6 +68,7 @@ public class KakaoServiceImpl implements KakaoService {
                     .accessToken(newAccessToken)
                     .refreshToken(newRefreshToken)
                     .username(kakaoUser.getUsername())
+                    .userStatus(kakaoUser.getStatus())
                     .build();
         }
 
@@ -78,6 +79,7 @@ public class KakaoServiceImpl implements KakaoService {
                 .username(kakaoUser.getUsername())
                 .periodId(kakaoUser.getPeriod().getId())
                 .period(kakaoUser.getPeriod().getPeriod())
+                .userStatus(kakaoUser.getStatus())
                 .trackName(kakaoUser.getPeriod().getTrack().getName())
                 .build();
 

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -62,10 +62,22 @@ public class KakaoServiceImpl implements KakaoService {
 
         refreshTokenService.updateRefreshToken(kakaoUser, newRefreshToken); // 리프레시 토큰 업데이트
 
+        if (kakaoUser.getPeriod() == null) {
+            return LoginResponseDto.builder()
+                    .accessToken(newAccessToken)
+                    .refreshToken(newRefreshToken)
+                    .username(kakaoUser.getUsername())
+                    .build();
+        }
+
+
         return LoginResponseDto.builder()
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
                 .username(kakaoUser.getUsername())
+                .periodId(kakaoUser.getPeriod().getId())
+                .period(kakaoUser.getPeriod().getPeriod())
+                .trackName(kakaoUser.getPeriod().getTrack().getName())
                 .build();
 
     }
@@ -90,7 +102,8 @@ public class KakaoServiceImpl implements KakaoService {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", "7cf9695ccd3477922a5d6ddef0793d97");
-        body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");
+//        body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");
+        body.add("redirect_uri", "http://localhost:3000");
         body.add("code", code);
 
         RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity

--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -162,11 +163,16 @@ public class KakaoServiceImpl implements KakaoService {
         return new KakaoUserInfoDto(id, nickname, image_url, email);
     }
 
+    @Transactional
     public User registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
 
         // DB 에 중복된 Kakao Id 가 있는지 확인
         Long kakaoId = kakaoUserInfo.getId();
         User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null);
+
+        if (kakaoUser.getPeriod() == null) {
+            kakaoUser.updateKakaoUserStatus();
+        }
 
         if (kakaoUser == null) {
 

--- a/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
@@ -101,6 +101,10 @@ public class User extends BaseEntity {
         this.status = UserStatus.LOGOUT;
     }
 
+    public void updateKakaoUserStatus() {
+        this.status = UserStatus.PENDING;
+    }
+
     public void updateProfile(String gitLink, String vlogLink,String intro,UserMbti mbti) {
         this.gitLink = gitLink;
         this.vlogLink = vlogLink;

--- a/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
@@ -101,10 +101,6 @@ public class User extends BaseEntity {
         this.status = UserStatus.LOGOUT;
     }
 
-    public void updateKakaoUserStatus() {
-        this.status = UserStatus.PENDING;
-    }
-
     public void updateProfile(String gitLink, String vlogLink,String intro,UserMbti mbti) {
         this.gitLink = gitLink;
         this.vlogLink = vlogLink;

--- a/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/entity/User.java
@@ -97,6 +97,10 @@ public class User extends BaseEntity {
         this.status = UserStatus.REFUSAL;
     }
 
+    public void updateKakaoUserPeriod(Period period) {
+        this.period = period;
+    }
+
     public void logout() {
         this.status = UserStatus.LOGOUT;
     }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -1,21 +1,15 @@
 package com.sparta.teamssc.domain.user.user.service;
 
-import com.sparta.teamssc.common.dto.ResponseDto;
-import com.sparta.teamssc.domain.period.dto.PeriodResponseDto;
 import com.sparta.teamssc.domain.period.entity.Period;
-import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
+import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.response.KakaoUserStatusResponse;
 import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
 import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
 import com.sparta.teamssc.domain.user.user.entity.User;
-import com.sparta.teamssc.domain.user.user.entity.UserStatus;
 import com.sparta.teamssc.domain.user.user.repository.userMapping.ProfileCardMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.List;
 
 public interface UserService {
     // 회원가입
@@ -53,7 +47,6 @@ public interface UserService {
 
     // 회원가입 대기 상태 유저 페이징
     Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period);
-
 
     // 카카오 가입 유저 기수 신청 상태 확인
     KakaoUserStatusResponse getKakaoUserStatus(String email);

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -11,6 +11,8 @@ import com.sparta.teamssc.domain.user.user.repository.userMapping.ProfileCardMap
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface UserService {
     // 회원가입
     void signup(SignupRequestDto signupRequestDto);

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -56,5 +56,7 @@ public interface UserService {
     // 카카오 가입 유저 기수 신청 상태 확인
     KakaoUserStatusResponse getKakaoUserStatus(String email);
 
+    void kakaoUserUpdatePeriod(Long periodId, String email);
+
 //    boolean verifyEmail(String username, String verificationCode);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.sparta.teamssc.domain.period.dto.PeriodResponseDto;
 import com.sparta.teamssc.domain.period.entity.Period;
 import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
+import com.sparta.teamssc.domain.user.auth.dto.response.KakaoUserStatusResponse;
 import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
 import com.sparta.teamssc.domain.user.user.dto.response.PendSignupResponseDto;
 import com.sparta.teamssc.domain.user.user.entity.User;
@@ -51,6 +52,9 @@ public interface UserService {
 
     // 회원가입 대기 상태 유저 페이징
     Page<PendSignupResponseDto> findPagedPendList(Pageable pageable, Period period);
+
+    // 카카오 가입 유저 기수 신청 상태 확인
+    KakaoUserStatusResponse getKakaoUserStatus(String email);
 
 //    boolean verifyEmail(String username, String verificationCode);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.sparta.teamssc.domain.period.entity.Period;
 import com.sparta.teamssc.domain.period.service.PeriodService;
 import com.sparta.teamssc.domain.user.auth.dto.request.LoginRequestDto;
 import com.sparta.teamssc.domain.user.auth.dto.request.SignupRequestDto;
+import com.sparta.teamssc.domain.user.auth.dto.response.KakaoUserStatusResponse;
 import com.sparta.teamssc.domain.user.auth.dto.response.LoginResponseDto;
 import com.sparta.teamssc.domain.user.auth.util.JwtUtil;
 import com.sparta.teamssc.domain.user.refreshToken.entity.RefreshToken;
@@ -259,5 +260,20 @@ public class UserServiceImpl implements UserService {
         return roles.stream()
                 .map(role -> new SimpleGrantedAuthority(role.getRole().getName()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public KakaoUserStatusResponse getKakaoUserStatus(String email) {
+        User user = getUserByEmail(email);
+
+        if (user.getPeriod() == null) {
+            return KakaoUserStatusResponse.builder().build();
+        }
+
+        return KakaoUserStatusResponse.builder()
+                .period(user.getPeriod().getPeriod())
+                .periodId(user.getPeriod().getId())
+                .trackName(user.getPeriod().getTrack().getName())
+                .build();
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -260,8 +260,10 @@ public class UserServiceImpl implements UserService {
                 .collect(Collectors.toList());
     }
 
+    // 카카오 가입 유저 기수 신청 상태 확인
     @Override
     public KakaoUserStatusResponse getKakaoUserStatus(String email) {
+
         User user = getUserByEmail(email);
 
         if (user.getPeriod() == null) {
@@ -273,5 +275,19 @@ public class UserServiceImpl implements UserService {
                 .periodId(user.getPeriod().getId())
                 .trackName(user.getPeriod().getTrack().getName())
                 .build();
+    }
+
+    // 카카오 유저 기수 신청
+    @Transactional
+    @Override
+    public void kakaoUserUpdatePeriod(Long periodId, String email) {
+
+        Period period = periodService.getPeriodById(periodId);
+        User user = getUserByEmail(email);
+        if (user.getPeriod() != null) {
+            throw new IllegalArgumentException("이미 트랙을 신청한 상태입니다.");
+        }
+
+        user.updateKakaoUserPeriod(period);
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/service/UserServiceImpl.java
@@ -136,8 +136,6 @@ public class UserServiceImpl implements UserService {
 
         User user = getUserByEmail(email);
 
-        user.logout();
-
         refreshTokenService.deleteRefreshToken(user);
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[SSC-91] 
[SSC-100]
[SSC-101]

## 📝 작업 내용
- 카카오 로그인 로직 수정
- 로그아웃 시 Status LOGOUT으로 변경시키던 로직 삭제 
( 카카오 유저는 승인을 받지않아도 로그인이 가능한데 로그아웃시 PENDING에서 LOGOUT으로 변경, 그리고 LOGOUT을 이용하여 진행되는 로직이 없어보임)
- 카카오 유저 기수 신청 상태 조회
- 카카오 유저 기수 신청 ( 카카오 유저는 기수 신청 없이도 회원 가입, 로그인이 가능하므로 로그인 이후 별도의 신청과정)

### 📸 스크린샷
- 일반 유저 로그인 창
![image](https://github.com/user-attachments/assets/ad92ef71-0f1f-4525-91b9-f49032822cdd)
- 일반 유저 로그인 시 바로 기수 페이지로 이동
![image](https://github.com/user-attachments/assets/96e5101a-d40e-4c59-aa62-c33a901a8d71)
- 카카오 유저 로그인 
![로그인](https://github.com/user-attachments/assets/7f7f9bfb-6783-49a9-a112-dd4defe8ff08)
- 기수 신청 페이지로 이동
![image](https://github.com/user-attachments/assets/e6b550b5-2b3a-41f9-9cf0-310f36cb2830)
- 기수 신청 시 신청 대기상태로 변경  
![image](https://github.com/user-attachments/assets/1ec0e964-2328-4fc9-b4da-46eace2b0cc7)
- 매니저가 승인 후에는 기수 페이지로 이동
![image](https://github.com/user-attachments/assets/1d44bb2f-16b9-490e-9095-b3e5a53bb668)


## 💬 리뷰 요구사항

-  로그아웃 시 Status LOGOUT으로 변경시키던 로직 삭제에 대해 의견 있으시면 의견 말해주세요!!!

[SSC-91]: https://dami8789.atlassian.net/browse/SSC-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SSC-100]: https://dami8789.atlassian.net/browse/SSC-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SSC-101]: https://dami8789.atlassian.net/browse/SSC-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ