### PR TITLE
fix[SSC-90]: 소셜 로그인 - 권한 중복등록 에러 해결

### DIFF
--- a/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/auth/service/KakaoServiceImpl.java
@@ -199,10 +199,11 @@ public class KakaoServiceImpl implements KakaoService {
                         .kakaoId(kakaoId)
                         .profileImage(kakaoUserInfo.getImageUrl())
                         .build();
+
+                userRoleService.userRoleAdd(kakaoUser, "user");
             }
 
             userRepository.save(kakaoUser);
-            userRoleService.userRoleAdd(kakaoUser, "user");
 
         }
         return kakaoUser;

--- a/src/main/java/com/sparta/teamssc/domain/user/role/userRole/repository/UserRoleRepository.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/role/userRole/repository/UserRoleRepository.java
@@ -1,9 +1,15 @@
 package com.sparta.teamssc.domain.user.role.userRole.repository;
 
 import com.sparta.teamssc.domain.user.role.userRole.entity.UserRole;
+import com.sparta.teamssc.domain.user.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+
+    @Query("DELETE FROM UserRole UR WHERE UR.user = :userId AND UR.role = :roleId")
+    void deleteByRole(@Param("userId")Long userId, @Param("role")Long roleId);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/role/userRole/service/UserRoleService.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/role/userRole/service/UserRoleService.java
@@ -3,5 +3,7 @@ package com.sparta.teamssc.domain.user.role.userRole.service;
 import com.sparta.teamssc.domain.user.user.entity.User;
 
 public interface UserRoleService {
-    void userRoleAdd(User user, String name);
+    void userRoleAdd(User user, String role);
+
+    void userRoleDelete(Long userId, Long roleId);
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/role/userRole/service/UserRoleServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/role/userRole/service/UserRoleServiceImpl.java
@@ -8,6 +8,8 @@ import com.sparta.teamssc.domain.user.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserRoleServiceImpl implements UserRoleService {
@@ -16,14 +18,21 @@ public class UserRoleServiceImpl implements UserRoleService {
     private final RoleService roleService;
 
     @Override
-    public void userRoleAdd(User user,String name) {
+    public void userRoleAdd(User user,String role) {
 
-        Role role = roleService.findRoleByName(name);
+        Role findRole = roleService.findRoleByName(role);
 
         UserRole userRole = UserRole.builder()
                 .user(user)
-                .role(role)
+                .role(findRole)
                 .build();
         userRoleRepository.save(userRole);
+    }
+
+    @Override
+    public void userRoleDelete(Long userId, Long roleId){
+
+        userRoleRepository.deleteByRole(userId, roleId);
+
     }
 }

--- a/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerServiceImpl.java
+++ b/src/main/java/com/sparta/teamssc/domain/user/user/managerService/ManagerServiceImpl.java
@@ -66,6 +66,7 @@ public class ManagerServiceImpl implements ManagerService{
 
     //매니저 권한 부여
     @Override
+    @Transactional
     public void approveManager(ApproveManagerRequestDto approveManagerRequestDto) {
 
         User user = userService.getUserByEmail(approveManagerRequestDto.getUserEmail());
@@ -77,6 +78,9 @@ public class ManagerServiceImpl implements ManagerService{
         }
 
         userRoleService.userRoleAdd(user,"manager");
+
+        // role 1 : 매니저권한 부여 후 유저 권한 삭제
+        userRoleService.userRoleDelete(user.getId(), 1L);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) [SSC-90] 

## 📝 작업 내용

> 일반 로그인 후 카카오 로그인 시 Role(user) 가 두개가 되는 에러 해결
> 매니저권한 부여 시 다중 Role(user,manager) 중 user 권한을 삭제하는 로직 추가

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


[SSC-90]: https://dami8789.atlassian.net/browse/SSC-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ